### PR TITLE
Prevent Python package install task from always being changed.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     pkg: "{{item}}"
     state: present
     update_cache: yes
+    cache_valid_time: 1800
   with_items: "{{ python_apt_packages_2 }}"
   when: python_install_2
 
@@ -12,6 +13,7 @@
     pkg: "{{item}}"
     state: present
     update_cache: yes
+    cache_valid_time: 1800
   with_items: "{{ python_apt_packages_3 }}"
   when: python_install_3
 


### PR DESCRIPTION
Hi again,
due to the set option `update_cache: yes` the tasks [_Ensure that Python2 packages are installed_](https://github.com/sunscrapers/ansible-role-python/blob/master/tasks/main.yml#L2) and [_Ensure that Python3 packages are installed_](https://github.com/sunscrapers/ansible-role-python/blob/master/tasks/main.yml#L10) are both updating the package cache on every run. This results in the task’s status always being „changed“.
You can prevent this by adding [`cache_valid_time`](http://docs.ansible.com/ansible/apt_module.html#options). I chose half an hour just because testing and playing around for half an hour is in my opinion much more likely than missing that new python update by half an hour.